### PR TITLE
Allow enter key to "ok" confirm boxes.

### DIFF
--- a/NM trade enhancement.user.js
+++ b/NM trade enhancement.user.js
@@ -1594,6 +1594,18 @@ async function addTradePreview (notification) {
     singleton.setInstances(Object.values(tips));
 }
 
+/**
+ * Allows you to hit enter with your keyboard to dismiss confirm boxes.
+ * @param {Event} e - keydown event
+ */
+async function okayNotification (e) {
+    const ENTER_KEYCODE = 13;
+    if (e.keyCode === ENTER_KEYCODE) {
+        const confirm = document.querySelector('#confirm-btn')
+        confirm && confirm.click();
+    }
+}
+
 // =============================================================================
 //                         Program execution start
 // =============================================================================
@@ -1601,6 +1613,7 @@ async function addTradePreview (notification) {
 fixAutoWithdrawnTrade();
 updateCardsInTrade();
 
+document.addEventListener("keydown", okayNotification);
 document.addEventListener("DOMContentLoaded", () => {
     forAllElements(document, "div.nm-modal.trade", addTradeWindowEnhancements);
     forAllElements(document, "div.nm-conversation--header", addLastActionAgo);


### PR DESCRIPTION
I regularly see the popup box, and get frustrated that I need my mouse to dismiss. It became clear when I was trying to discard a lot of my commons. Here's an example popup

![image](https://user-images.githubusercontent.com/769039/123554167-a0710f00-d733-11eb-8ea7-0e409dea828b.png)
